### PR TITLE
Backport: Improve snapshot functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ export PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
 
 ./proxmox-api-go migrate 123 migrate-to-proxmox-node-name
 
-./proxmox-api-go createQemuSnapshot vm-name snapshot_name
-
-./proxmox-api-go deleteQemuSnapshot vm-name snapshot_name
-
-./proxmox-api-go listQemuSnapshot vm-name
-
-./proxmox-api-go rollbackQemu vm-name
-
 ./proxmox-api-go getResourceList
 
 ./proxmox-api-go getVmList

--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -18,7 +18,7 @@ var (
 			id := cli.ValidateIntIDset(args, "GuestID")
 			snapName := cli.RequiredIDset(args, 1, "SnapshotName")
 			config := proxmox.ConfigSnapshot{
-				Name:        snapName,
+				Name:        proxmox.SnapshotName(snapName),
 				Description: cli.OptionalIDset(args, 2),
 				VmState:     memory,
 			}

--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -29,7 +29,7 @@ var (
 			if err != nil {
 				return
 			}
-			err = config.CreateSnapshot(client, vmr)
+			err = config.Create(client, vmr)
 			if err != nil {
 				return
 			}

--- a/cli/command/delete/delete-snapshot.go
+++ b/cli/command/delete/delete-snapshot.go
@@ -14,7 +14,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateIntIDset(args, "GuestID")
 			snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-			_, err = proxmox.DeleteSnapshot(cli.NewClient(), proxmox.NewVmRef(id), snapName)
+			_, err = proxmox.DeleteSnapshot(cli.NewClient(), proxmox.NewVmRef(id), proxmox.SnapshotName(snapName))
 			if err != nil {
 				return
 			}

--- a/cli/command/delete/delete-snapshot.go
+++ b/cli/command/delete/delete-snapshot.go
@@ -14,7 +14,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateIntIDset(args, "GuestID")
 			snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-			_, err = proxmox.DeleteSnapshot(cli.NewClient(), proxmox.NewVmRef(id), proxmox.SnapshotName(snapName))
+			_, err = proxmox.SnapshotName(snapName).Delete(cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				return
 			}

--- a/cli/command/guest/guest-rollback.go
+++ b/cli/command/guest/guest-rollback.go
@@ -15,7 +15,7 @@ var guest_rollbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-		_, err = proxmox.RollbackSnapshot(cli.NewClient(), vmr, snapName)
+		_, err = proxmox.SnapshotName(snapName).Rollback(cli.NewClient(), vmr)
 		if err == nil {
 			fmt.Fprintf(GuestCmd.OutOrStdout(), "Guest with id (%d) has been rolled back to snapshot (%s)\n", vmr.VmId(), snapName)
 		}

--- a/cli/command/list/list-snapshots.go
+++ b/cli/command/list/list-snapshots.go
@@ -24,9 +24,9 @@ var (
 			var list []*proxmox.Snapshot
 			if noTree {
 				noTree = false
-				list = rawSnapshots.FormatSnapshotsList()
+				list = rawSnapshots.FormatList()
 			} else {
-				list = rawSnapshots.FormatSnapshotsTree()
+				list = rawSnapshots.FormatTree()
 			}
 			if len(list) == 0 {
 				listCmd.Printf("Guest with ID (%d) has no snapshots", id)

--- a/cli/command/update/update-snapshotdescription.go
+++ b/cli/command/update/update-snapshotdescription.go
@@ -14,7 +14,7 @@ var update_snapshotCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
 		des := cli.OptionalIDset(args, 2)
-		err = proxmox.UpdateSnapshotDescription(cli.NewClient(), proxmox.NewVmRef(id), snapName, des)
+		err = proxmox.UpdateSnapshotDescription(cli.NewClient(), proxmox.NewVmRef(id), proxmox.SnapshotName(snapName), des)
 		if err != nil {
 			return
 		}

--- a/cli/command/update/update-snapshotdescription.go
+++ b/cli/command/update/update-snapshotdescription.go
@@ -14,7 +14,7 @@ var update_snapshotCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
 		des := cli.OptionalIDset(args, 2)
-		err = proxmox.UpdateSnapshotDescription(cli.NewClient(), proxmox.NewVmRef(id), proxmox.SnapshotName(snapName), des)
+		err = proxmox.SnapshotName(snapName).Update(cli.NewClient(), proxmox.NewVmRef(id), des)
 		if err != nil {
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func main() {
 	case "deleteQemuSnapshot":
 		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
 		failError(err)
-		jbody, err = c.DeleteQemuSnapshot(sourceVmr, flag.Args()[2])
+		jbody, err = c.DeleteQemuSnapshot(sourceVmr, proxmox.SnapshotName(flag.Args()[2]))
 		failError(err)
 
 	case "listQemuSnapshot":

--- a/main.go
+++ b/main.go
@@ -240,61 +240,6 @@ func main() {
 		failError(config.UpdateConfig(vmr, c))
 		log.Println("Complete")
 
-	case "createQemuSnapshot":
-		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
-		failError(err)
-		jbody, err = c.CreateQemuSnapshot(sourceVmr, flag.Args()[2])
-		failError(err)
-
-	case "deleteQemuSnapshot":
-		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
-		failError(err)
-		jbody, err = c.DeleteQemuSnapshot(sourceVmr, proxmox.SnapshotName(flag.Args()[2]))
-		failError(err)
-
-	case "listQemuSnapshot":
-		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
-		if err == nil {
-			jbody, _, err = c.ListQemuSnapshot(sourceVmr)
-			if rec, ok := jbody.(map[string]interface{}); ok {
-				temp := rec["data"].([]interface{})
-				for _, val := range temp {
-					snapshotName := val.(map[string]interface{})
-					if snapshotName["name"] != "current" {
-						fmt.Println(snapshotName["name"])
-					}
-				}
-			} else {
-				fmt.Printf("record not a map[string]interface{}: %v\n", jbody)
-			}
-		}
-		failError(err)
-
-	case "listQemuSnapshot2":
-		sourceVmrs, err := c.GetVmRefsByName(flag.Args()[1])
-		if err == nil {
-			for _, sourceVmr := range sourceVmrs {
-				jbody, _, err = c.ListQemuSnapshot(sourceVmr)
-				if rec, ok := jbody.(map[string]interface{}); ok {
-					temp := rec["data"].([]interface{})
-					for _, val := range temp {
-						snapshotName := val.(map[string]interface{})
-						if snapshotName["name"] != "current" {
-							fmt.Printf("%d@%s:%s\n", sourceVmr.VmId(), sourceVmr.Node(), snapshotName["name"])
-						}
-					}
-				} else {
-					fmt.Printf("record not a map[string]interface{}: %v\n", jbody)
-				}
-			}
-		}
-		failError(err)
-
-	case "rollbackQemu":
-		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
-		failError(err)
-		jbody, err = c.RollbackQemuVm(sourceVmr, proxmox.SnapshotName(flag.Args()[2]))
-		failError(err)
 		// TODO make sshforward in new cli
 	case "sshforward":
 		vmr = proxmox.NewVmRef(vmid)

--- a/main.go
+++ b/main.go
@@ -293,7 +293,7 @@ func main() {
 	case "rollbackQemu":
 		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
 		failError(err)
-		jbody, err = c.RollbackQemuVm(sourceVmr, flag.Args()[2])
+		jbody, err = c.RollbackQemuVm(sourceVmr, proxmox.SnapshotName(flag.Args()[2]))
 		failError(err)
 		// TODO make sshforward in new cli
 	case "sshforward":

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -684,7 +684,7 @@ func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus
 
 // DEPRECATED superseded by DeleteSnapshot()
 func (c *Client) DeleteQemuSnapshot(vmr *VmRef, snapshotName SnapshotName) (exitStatus string, err error) {
-	return DeleteSnapshot(c, vmr, snapshotName)
+	return snapshotName.Delete(c, vmr)
 }
 
 // DEPRECATED superseded by ListSnapshots()
@@ -706,8 +706,8 @@ func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface
 }
 
 // DEPRECATED superseded by RollbackSnapshot()
-func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot string) (exitStatus string, err error) {
-	return RollbackSnapshot(c, vmr, snapshot)
+func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot SnapshotName) (exitStatus string, err error) {
+	return snapshot.Rollback(c, vmr)
 }
 
 // DEPRECATED SetVmConfig - send config options

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -683,7 +683,7 @@ func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus
 }
 
 // DEPRECATED superseded by DeleteSnapshot()
-func (c *Client) DeleteQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
+func (c *Client) DeleteQemuSnapshot(vmr *VmRef, snapshotName SnapshotName) (exitStatus string, err error) {
 	return DeleteSnapshot(c, vmr, snapshotName)
 }
 

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -657,59 +657,6 @@ func (c *Client) CloneQemuVm(vmr *VmRef, vmParams map[string]interface{}) (exitS
 	return
 }
 
-// DEPRECATED superseded by CreateSnapshot()
-func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	snapshotParams := map[string]interface{}{
-		"snapname": snapshotName,
-	}
-	reqbody := ParamsToBody(snapshotParams)
-	if err != nil {
-		return "", err
-	}
-	url := fmt.Sprintf("/nodes/%s/%s/%d/snapshot/", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
-	if err == nil {
-		taskResponse, err := ResponseJSON(resp)
-		if err != nil {
-			return "", err
-		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
-		if err != nil {
-			return "", err
-		}
-	}
-	return
-}
-
-// DEPRECATED superseded by DeleteSnapshot()
-func (c *Client) DeleteQemuSnapshot(vmr *VmRef, snapshotName SnapshotName) (exitStatus string, err error) {
-	return snapshotName.Delete(c, vmr)
-}
-
-// DEPRECATED superseded by ListSnapshots()
-func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface{}, exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return nil, "", err
-	}
-	url := fmt.Sprintf("/nodes/%s/%s/%d/snapshot/", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Get(url, nil, nil)
-	if err == nil {
-		taskResponse, err := ResponseJSON(resp)
-		if err != nil {
-			return nil, "", err
-		}
-		return taskResponse, "", nil
-	}
-	return
-}
-
-// DEPRECATED superseded by RollbackSnapshot()
-func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot SnapshotName) (exitStatus string, err error) {
-	return snapshot.Rollback(c, vmr)
-}
-
 // DEPRECATED SetVmConfig - send config options
 func (c *Client) SetVmConfig(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
 	return c.postWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config")

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -23,17 +23,25 @@ func (config ConfigSnapshot) mapToApiValues() map[string]interface{} {
 }
 
 func (config ConfigSnapshot) CreateSnapshot(c *Client, vmr *VmRef) (err error) {
-	params := config.mapToApiValues()
 	err = c.CheckVmRef(vmr)
 	if err != nil {
 		return
 	}
+	err = config.Validate()
+	if err != nil {
+		return
+	}
+	params := config.mapToApiValues()
 	_, err = c.postWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/")
 	if err != nil {
 		params, _ := json.Marshal(&params)
 		return fmt.Errorf("error creating Snapshot: %v, (params: %v)", err, string(params))
 	}
 	return
+}
+
+func (config ConfigSnapshot) Validate() error {
+	return config.Name.Validate()
 }
 
 type rawSnapshots []interface{}

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -3,7 +3,9 @@ package proxmox
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
+	"unicode"
 )
 
 type ConfigSnapshot struct {
@@ -50,11 +52,19 @@ func UpdateSnapshotDescription(c *Client, vmr *VmRef, snapshot SnapshotName, des
 	if err != nil {
 		return
 	}
+	err = snapshot.Validate()
+	if err != nil {
+		return
+	}
 	return c.put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+string(snapshot)+"/config")
 }
 
 func DeleteSnapshot(c *Client, vmr *VmRef, snapshot SnapshotName) (exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
+	if err != nil {
+		return
+	}
+	err = snapshot.Validate()
 	if err != nil {
 		return
 	}
@@ -128,3 +138,27 @@ func (raw rawSnapshots) FormatSnapshotsTree() (tree []*Snapshot) {
 // First character must be a letter
 // Must only contain the following characters: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_
 type SnapshotName string
+
+const (
+	SnapshotName_Error_IllegalCharacters string = "SnapshotName must only contain the following characters: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+	SnapshotName_Error_MaxLength         string = "SnapshotName must be at most 40 characters long"
+	SnapshotName_Error_MinLength         string = "SnapshotName must be at least 3 characters long"
+	SnapshotName_Error_StartNoLetter     string = "SnapshotName must start with a letter"
+)
+
+func (name SnapshotName) Validate() error {
+	regex, _ := regexp.Compile(`^([a-zA-Z])([a-z]|[A-Z]|[0-9]|_|-){2,39}$`)
+	if !regex.Match([]byte(name)) {
+		if len(name) < 3 {
+			return fmt.Errorf(SnapshotName_Error_MinLength)
+		}
+		if len(name) > 40 {
+			return fmt.Errorf(SnapshotName_Error_MaxLength)
+		}
+		if !unicode.IsLetter(rune(name[0])) {
+			return fmt.Errorf(SnapshotName_Error_StartNoLetter)
+		}
+		return fmt.Errorf(SnapshotName_Error_IllegalCharacters)
+	}
+	return nil
+}

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -7,9 +7,9 @@ import (
 )
 
 type ConfigSnapshot struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	VmState     bool   `json:"ram,omitempty"`
+	Name        SnapshotName `json:"name,omitempty"`
+	Description string       `json:"description,omitempty"`
+	VmState     bool         `json:"ram,omitempty"`
 }
 
 func (config ConfigSnapshot) mapToApiValues() map[string]interface{} {
@@ -45,20 +45,20 @@ func ListSnapshots(c *Client, vmr *VmRef) (rawSnapshots, error) {
 }
 
 // Can only be used to update the description of an already existing snapshot
-func UpdateSnapshotDescription(c *Client, vmr *VmRef, snapshot, description string) (err error) {
+func UpdateSnapshotDescription(c *Client, vmr *VmRef, snapshot SnapshotName, description string) (err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
 		return
 	}
-	return c.put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/config")
+	return c.put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+string(snapshot)+"/config")
 }
 
-func DeleteSnapshot(c *Client, vmr *VmRef, snapshot string) (exitStatus string, err error) {
+func DeleteSnapshot(c *Client, vmr *VmRef, snapshot SnapshotName) (exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
 		return
 	}
-	return c.deleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + snapshot)
+	return c.deleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + string(snapshot))
 }
 
 func RollbackSnapshot(c *Client, vmr *VmRef, snapshot string) (exitStatus string, err error) {
@@ -71,12 +71,12 @@ func RollbackSnapshot(c *Client, vmr *VmRef, snapshot string) (exitStatus string
 
 // Used for formatting the output when retrieving snapshots
 type Snapshot struct {
-	Name        string      `json:"name"`
-	SnapTime    uint        `json:"time,omitempty"`
-	Description string      `json:"description,omitempty"`
-	VmState     bool        `json:"ram,omitempty"`
-	Children    []*Snapshot `json:"children,omitempty"`
-	Parent      string      `json:"parent,omitempty"`
+	Name        SnapshotName `json:"name"`
+	SnapTime    uint         `json:"time,omitempty"`
+	Description string       `json:"description,omitempty"`
+	VmState     bool         `json:"ram,omitempty"`
+	Children    []*Snapshot  `json:"children,omitempty"`
+	Parent      SnapshotName `json:"parent,omitempty"`
 }
 
 // Formats the taskResponse as a list of snapshots
@@ -88,10 +88,10 @@ func (raw rawSnapshots) FormatSnapshotsList() (list []*Snapshot) {
 			list[i].Description = e.(map[string]interface{})["description"].(string)
 		}
 		if _, isSet := e.(map[string]interface{})["name"]; isSet {
-			list[i].Name = e.(map[string]interface{})["name"].(string)
+			list[i].Name = SnapshotName(e.(map[string]interface{})["name"].(string))
 		}
 		if _, isSet := e.(map[string]interface{})["parent"]; isSet {
-			list[i].Parent = e.(map[string]interface{})["parent"].(string)
+			list[i].Parent = SnapshotName(e.(map[string]interface{})["parent"].(string))
 		}
 		if _, isSet := e.(map[string]interface{})["snaptime"]; isSet {
 			list[i].SnapTime = uint(e.(map[string]interface{})["snaptime"].(float64))
@@ -122,3 +122,9 @@ func (raw rawSnapshots) FormatSnapshotsTree() (tree []*Snapshot) {
 	}
 	return
 }
+
+// Minimum length of 3 characters
+// Maximum length of 40 characters
+// First character must be a letter
+// Must only contain the following characters: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_
+type SnapshotName string

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -98,7 +98,7 @@ type Snapshot struct {
 }
 
 // Formats the taskResponse as a list of snapshots
-func (raw rawSnapshots) FormatSnapshotsList() (list []*Snapshot) {
+func (raw rawSnapshots) FormatList() (list []*Snapshot) {
 	list = make([]*Snapshot, len(raw))
 	for i, e := range raw {
 		list[i] = &Snapshot{}
@@ -122,8 +122,8 @@ func (raw rawSnapshots) FormatSnapshotsList() (list []*Snapshot) {
 }
 
 // Formats a list of snapshots as a tree of snapshots
-func (raw rawSnapshots) FormatSnapshotsTree() (tree []*Snapshot) {
-	list := raw.FormatSnapshotsList()
+func (raw rawSnapshots) FormatTree() (tree []*Snapshot) {
+	list := raw.FormatList()
 	for _, e := range list {
 		for _, ee := range list {
 			if e.Parent == ee.Name {

--- a/proxmox/snapshot_test.go
+++ b/proxmox/snapshot_test.go
@@ -9,6 +9,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_ConfigSnapshot_Validate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input ConfigSnapshot
+		err   bool
+	}{
+		// Valid
+		{name: "Valid ConfigSnapshot",
+			input: ConfigSnapshot{Name: SnapshotName(test_data_snapshot.SnapshotName_Max_Legal())},
+		},
+		// Invalid
+		{name: "Invalid ConfigSnapshot",
+			input: ConfigSnapshot{Name: SnapshotName(test_data_snapshot.SnapshotName_Max_Illegal())},
+			err:   true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			if test.err {
+				require.Error(t, test.input.Validate(), test.name)
+			} else {
+				require.NoError(t, test.input.Validate(), test.name)
+			}
+		})
+	}
+}
+
 // Test the formatting logic to build the tree of snapshots
 func Test_FormatSnapshotsTree(t *testing.T) {
 	input := test_FormatSnapshots_Input()

--- a/proxmox/snapshot_test.go
+++ b/proxmox/snapshot_test.go
@@ -2,8 +2,10 @@ package proxmox
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
+	"github.com/Tinyblargon/proxmox-go-sdk/test/data/test_data_snapshot"
 	"github.com/stretchr/testify/require"
 )
 
@@ -203,4 +205,39 @@ func test_FormatSnapshotsList_Output() []string {
 		"name":"bb","time":1666361866,"description":"aA1!","ram":true},{
 		"name":"bba","time":1666362071,"parent":"bb"},{
 		"name":"bbb","time":1666362062,"parent":"bb"}]`}
+}
+
+func Test_SnapshotName_Validate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		err   error
+	}{
+		// Valid
+		{name: "Valid", input: test_data_snapshot.SnapshotName_Legal()},
+		// Invalid
+		{name: "Invalid SnapshotName_Error_MinLength",
+			input: []string{"", test_data_snapshot.SnapshotName_Min_Illegal()},
+			err:   errors.New(SnapshotName_Error_MinLength),
+		},
+		{name: "Invalid SnapshotName_Error_MaxLength",
+			input: []string{test_data_snapshot.SnapshotName_Max_Illegal()},
+			err:   errors.New(SnapshotName_Error_MaxLength),
+		},
+		{name: "Invalid SnapshotName_Error_StartNoLetter",
+			input: test_data_snapshot.SnapshotName_Start_Illegal(),
+			err:   errors.New(SnapshotName_Error_StartNoLetter),
+		},
+		{name: "Invalid SnapshotName_Error_StartNoLetter",
+			input: test_data_snapshot.SnapshotName_Character_Illegal(),
+			err:   errors.New(SnapshotName_Error_IllegalCharacters),
+		},
+	}
+	for _, test := range tests {
+		for _, snapshot := range test.input {
+			t.Run(test.name+" :"+snapshot, func(*testing.T) {
+				require.Equal(t, SnapshotName(snapshot).Validate(), test.err, test.name+" :"+snapshot)
+			})
+		}
+	}
 }

--- a/proxmox/snapshot_test.go
+++ b/proxmox/snapshot_test.go
@@ -37,26 +37,26 @@ func Test_ConfigSnapshot_Validate(t *testing.T) {
 }
 
 // Test the formatting logic to build the tree of snapshots
-func Test_FormatSnapshotsTree(t *testing.T) {
-	input := test_FormatSnapshots_Input()
-	output := test_FormatSnapshotsTree_Output()
+func Test_rawSnapshots_FormatTree(t *testing.T) {
+	input := test_rawSnapshots_FormatSnapshots_Input()
+	output := test_rawSnapshots_FormatTree_Output()
 	for i, e := range input {
-		result, _ := json.Marshal(e.FormatSnapshotsTree())
+		result, _ := json.Marshal(e.FormatTree())
 		require.JSONEq(t, output[i], string(result))
 	}
 }
 
 // Test the formatting logic to build the list of snapshots
-func Test_FormatSnapshotsList(t *testing.T) {
-	input := test_FormatSnapshots_Input()
-	output := test_FormatSnapshotsList_Output()
+func Test_rawSnapshots_FormatList(t *testing.T) {
+	input := test_rawSnapshots_FormatSnapshots_Input()
+	output := test_rawSnapshots_FormatList_Output()
 	for i, e := range input {
-		result, _ := json.Marshal(e.FormatSnapshotsList())
+		result, _ := json.Marshal(e.FormatList())
 		require.JSONEq(t, output[i], string(result))
 	}
 }
 
-func test_FormatSnapshots_Input() []rawSnapshots {
+func test_rawSnapshots_FormatSnapshots_Input() []rawSnapshots {
 	return []rawSnapshots{{map[string]interface{}{
 		"name":        "aa",
 		"snaptime":    float64(1666361849),
@@ -184,7 +184,7 @@ func test_FormatSnapshots_Input() []rawSnapshots {
 	}}}
 }
 
-func test_FormatSnapshotsTree_Output() []string {
+func test_rawSnapshots_FormatTree_Output() []string {
 	return []string{`[{
 		"name":"aa","time":1666361849,"children":[{
 			"name":"aaa","time":1666361866,"ram":true,"children":[{
@@ -209,7 +209,7 @@ func test_FormatSnapshotsTree_Output() []string {
 			"name":"bbb","time":1666362062}]}]`}
 }
 
-func test_FormatSnapshotsList_Output() []string {
+func test_rawSnapshots_FormatList_Output() []string {
 	return []string{`[{
 		"name":"aa","time":1666361849},{
 		"name":"aaa","time":1666361866,"ram":true,"parent":"aa"},{

--- a/test/data/test_data_snapshot/type_SnapshotName.go
+++ b/test/data/test_data_snapshot/type_SnapshotName.go
@@ -1,0 +1,131 @@
+package test_data_snapshot
+
+// illegal character
+func SnapshotName_Character_Illegal() []string {
+	return []string{
+		"aBc123!4567890_-",
+		"Qwer@ty-1234_ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		"x1y2#z3_4-5-6-7-8-9",
+		"HelloWo$rld_2023",
+		"Ab1_%cd2_ef3-gh4-ij5",
+		"a-_-^_-_-_-_-_-_-_-_-_-",
+		"snaps&hotName_2433242",
+		"A1_B2-*C3_D4-E5_F6",
+		"Xyz-123(_456_789-0",
+		"Test_Cas)e-123_456_789_0",
+		"a_1+",
+		"B-c_=2-D",
+		"E3_f4-G5_:H6-I7",
+		"JKL_MNO_PQ;R-STU_VWX_YZ0",
+		"aBgnhfjkfgd'ihfghudsfgio",
+		`Cdsdjfidshfu"isdghfsgffghdsufsdhfgdsfuah`,
+		"Ef-`gh",
+		"Ij-k~l-mn",
+		"Op-qr-st-u-vw-xy-z0-12-34-56-[78-90",
+		"Abcd_1234-EFGH_]5678-IJKL_9012",
+		"M-n-Op-qR-sT-uV{-wX-yZ",
+		"a_b-c_d_e-f_g_h_}i_j_k_l_m_n-o-p-q-r-s-t",
+		"Aa1_Bb2-C,c3_Dd4-Ee5_Ff6-Gg7_Hh8-Ii9",
+		"JjKkLl-MmNnOo.PpQqRrSsTtUuVvWwXxYyZz01",
+		"A->1",
+		"B-2<_C-3",
+		"D-4_?E-5-F-6",
+		"G-7-H/-8-I-9",
+		`J-0_K-\1-L-2-M-3-N-4-O-5-P-6-Q-7-R-8-S-9`,
+		"T-0_U-1-|V-2-W-3-X-4-Y-5-Z-6-7-8-9-0",
+		"a2😀",
+	}
+}
+
+// 40 valid characters
+func SnapshotName_Max_Legal() string {
+	return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"
+}
+
+// 41 invalid characters
+func SnapshotName_Max_Illegal() string {
+	return SnapshotName_Max_Legal() + "A"
+}
+
+// 3 valid characters
+func SnapshotName_Min_Legal() string {
+	return SnapshotName_Min_Illegal() + "c"
+}
+
+// 2 invalid characters
+func SnapshotName_Min_Illegal() string {
+	return "ab"
+}
+
+// legal starting character
+func SnapshotName_Start_Legal() string {
+	return "abc"
+}
+
+// illegal starting character
+func SnapshotName_Start_Illegal() []string {
+	return []string{
+		"_" + SnapshotName_Start_Legal(),
+		"-" + SnapshotName_Start_Legal(),
+		"0" + SnapshotName_Start_Legal(),
+		"5" + SnapshotName_Start_Legal(),
+	}
+}
+
+func SnapshotName_Legal() []string {
+	return []string{
+		"aBc1234567890_-",
+		"Qwerty-1234_ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		"x1y2z3_4-5-6-7-8-9",
+		"HelloWorld_2023",
+		"Ab1_cd2_ef3-gh4-ij5",
+		"a-_-_-_-_-_-_-_-_-_-_-",
+		"snapshotName_2433242",
+		"A1_B2-C3_D4-E5_F6",
+		"Xyz-123_456_789-0",
+		"Test_Case-123_456_789_0",
+		"a_1",
+		"B-c_2-D",
+		"E3_f4-G5_H6-I7",
+		"JKL_MNO_PQR-STU_VWX_YZ0",
+		"aBgnhfjkfgdihfghudsfgio",
+		"Cdsdjfidshfuisdghfsgffghdsufsdhfgdsfuahs",
+		"Ef-gh",
+		"Ij-kl-mn",
+		"Op-qr-st-u-vw-xy-z0-12-34-56-78-90",
+		"Abcd_1234-EFGH_5678-IJKL_9012",
+		"M-n-Op-qR-sT-uV-wX-yZ",
+		"a_b-c_d_e-f_g_h_i_j_k_l_m_n-o-p-q-r-s-t-",
+		"Aa1_Bb2-Cc3_Dd4-Ee5_Ff6-Gg7_Hh8-Ii9",
+		"JjKkLl-MmNnOoPpQqRrSsTtUuVvWwXxYyZz01",
+		"A-1",
+		"B-2_C-3",
+		"D-4_E-5-F-6",
+		"G-7-H-8-I-9",
+		"J-0_K-1-L-2-M-3-N-4-O-5-P-6-Q-7-R-8-S-9",
+		"T-0_U-1-V-2-W-3-X-4-Y-5-Z-6-7-8-9-0",
+		"a2B",
+		"c4D",
+		"e6F-g8H-i0J",
+		"k2L-m4N-o6P-q8R-s0T",
+		"u2V-w4X-y6Z-01-23-45-67-89-0",
+		"Abc_1234-Def_5678-Ghi_9012-Jkl_3456-Mno_",
+		"Pqr_2345-Stu_6789-Vwx_0123-Yz0_4567",
+		"a-B",
+		"c-D_e-F",
+		"g-H_i-J-k-L",
+		"m-N-o-P_q-R-s-T-u-V-w-X-y-Z-0",
+		"A_1b2-C3d4_E5f6-G7h8_I9j0-K1l2-M3n4",
+		"O5p6-Q7r8-S9t0-U1v2-W3x4-Y5z6-01",
+		"A2b3-C4d5-E6f7-G8h9-I0j1-K2l3-M4n5-O6",
+		"P7q8-R9s0-T1u2-V3w4-X5y6-Z7-89-01-23-45-",
+		"Ab_12-cD_34-eF_56-gH_78-iJ_90-kL_12-mN_3",
+		"O5p6-Q7r8-S9t0-U1v2-W3x4-Y5z6-01-23-45",
+		"A7b8-C9d0-E1f2-G3h4-I5j6-K7l8-M9n0-O1p2-",
+		"S5t6-U7v8-W9x0-Y1z2-34-56-78-90-12-34-56",
+		"Ab1C_d2E-F3G_h4I-J5k6L-m7N-o8P-q9R-s0T-u",
+		SnapshotName_Max_Legal(),
+		SnapshotName_Min_Legal(),
+		SnapshotName_Start_Legal(),
+	}
+}


### PR DESCRIPTION
Continuation of: https://github.com/Telmate/proxmox-api-go/pull/274

Work done this PR:

- Added `SnapshotName` variable ebec66402f03f43b74a0420136b95e38da71b0a0
- Ensured all the type casting between SnapshotName and string is done correctly
- Added `SnapshotName.Validate()` 8c2628be374d5d1c5219d588df27ca1af6002fe0
- Added test for `SnapshotName.Validate()` 8c2628be374d5d1c5219d588df27ca1af6002fe0
- Added `ConfigSnapshot.Validate()` c166e0b6d06353911b7c78fd4b27cf20eed3c9f1
- Added test for `ConfigSnapshot.Validate()` c166e0b6d06353911b7c78fd4b27cf20eed3c9f1
- Restructured `proxmox/snapshot.go` to conform to the style guide. 8b83ac6b1566dbf90a3f69bb47096b729757ee6e 6ee00b5e4fbc22f377271be433788ecf1fd13409
- Removed deprecated snapshot code 4cb6fc02ce5bfd2511fd5607443a7b802739239c