### PR TITLE
Overhaul: `VmRef`

### DIFF
--- a/cli/command/get/get-guest.go
+++ b/cli/command/get/get-guest.go
@@ -14,7 +14,7 @@ var get_guestCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		vmr := proxmox.NewVmRef(id)
 		c := cli.NewClient()
-		err = c.CheckVmRef(vmr)
+		err = vmr.Check(c)
 		if err != nil {
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 
 	case "getConfig":
 		vmr = proxmox.NewVmRef(vmid)
-		err := c.CheckVmRef(vmr)
+		err := vmr.Check(c)
 		failError(err)
 		vmType := vmr.GetVmType()
 		var config interface{}
@@ -134,7 +134,7 @@ func main() {
 		// TODO make getNetworkInterfaces in new cli
 	case "getNetworkInterfaces":
 		vmr = proxmox.NewVmRef(vmid)
-		err := c.CheckVmRef(vmr)
+		err := vmr.Check(c)
 		failError(err)
 		networkInterfaces, err := c.GetVmAgentNetworkInterfaces(vmr)
 		failError(err)

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -34,65 +34,6 @@ type Client struct {
 	TaskTimeout int
 }
 
-// VmRef - virtual machine ref parts
-// map[type:qemu node:proxmox1-xx id:qemu/132 diskread:5.57424738e+08 disk:0 netin:5.9297450593e+10 mem:3.3235968e+09 uptime:1.4567097e+07 vmid:132 template:0 maxcpu:2 netout:6.053310416e+09 maxdisk:3.4359738368e+10 maxmem:8.592031744e+09 diskwrite:1.49663619584e+12 status:running cpu:0.00386980694947209 name:appt-app1-dev.xxx.xx]
-type VmRef struct {
-	vmId    int
-	node    string
-	pool    string
-	vmType  string
-	haState string
-	haGroup string
-}
-
-func (vmr *VmRef) SetNode(node string) {
-	vmr.node = node
-}
-
-func (vmr *VmRef) SetPool(pool string) {
-	vmr.pool = pool
-}
-
-func (vmr *VmRef) SetVmType(vmType string) {
-	vmr.vmType = vmType
-}
-
-func (vmr *VmRef) GetVmType() string {
-	return vmr.vmType
-}
-
-func (vmr *VmRef) VmId() int {
-	return vmr.vmId
-}
-
-func (vmr *VmRef) Node() string {
-	return vmr.node
-}
-
-func (vmr *VmRef) Pool() string {
-	return vmr.pool
-}
-
-func (vmr *VmRef) HaState() string {
-	return vmr.haState
-}
-
-func (vmr *VmRef) HaGroup() string {
-	return vmr.haGroup
-}
-
-func (vmr *VmRef) nilCheck() error {
-	if vmr == nil {
-		return errors.New("vm reference may not be nil")
-	}
-	return nil
-}
-
-func NewVmRef(vmId int) (vmr *VmRef) {
-	vmr = &VmRef{vmId: vmId, node: "", vmType: ""}
-	return
-}
-
 func NewClient(apiUrl string, hclient *http.Client, http_headers string, tls *tls.Config, proxyString string, taskTimeout int) (client *Client, err error) {
 	var sess *Session
 	sess, err_s := NewSession(apiUrl, hclient, proxyString, tls)

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -117,13 +117,6 @@ func (c *Client) GetVmList() (map[string]interface{}, error) {
 	return map[string]interface{}{"data": list}, err
 }
 
-func (c *Client) CheckVmRef(vmr *VmRef) (err error) {
-	if vmr.node == "" || vmr.vmType == "" {
-		_, err = c.GetVmInfo(vmr)
-	}
-	return
-}
-
 func (c *Client) GetVmInfo(vmr *VmRef) (vmInfo map[string]interface{}, err error) {
 	vms, err := c.GetResourceList(resourceListGuest)
 	if err != nil {
@@ -186,7 +179,7 @@ func (c *Client) GetVmRefsByName(vmName string) (vmrs []*VmRef, err error) {
 }
 
 func (c *Client) GetVmState(vmr *VmRef) (vmState map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +187,7 @@ func (c *Client) GetVmState(vmr *VmRef) (vmState map[string]interface{}, err err
 }
 
 func (c *Client) GetVmConfig(vmr *VmRef) (vmConfig map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +195,7 @@ func (c *Client) GetVmConfig(vmr *VmRef) (vmConfig map[string]interface{}, err e
 }
 
 func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +213,7 @@ func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus
 }
 
 func (c *Client) GetStorageContent(vmr *VmRef, storageName string) (data map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +229,7 @@ func (c *Client) GetStorageContent(vmr *VmRef, storageName string) (data map[str
 }
 
 func (c *Client) GetVmSpiceProxy(vmr *VmRef) (vmSpiceProxy map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +282,7 @@ func (c *Client) GetVmAgentNetworkInterfaces(vmr *VmRef) ([]AgentNetworkInterfac
 }
 
 func (c *Client) doAgentGet(vmr *VmRef, command string, output interface{}) error {
-	err := c.CheckVmRef(vmr)
+	err := vmr.Check(c)
 	if err != nil {
 		return err
 	}
@@ -304,7 +297,7 @@ func (c *Client) doAgentGet(vmr *VmRef, command string, output interface{}) erro
 }
 
 func (c *Client) CreateTemplate(vmr *VmRef) error {
-	err := c.CheckVmRef(vmr)
+	err := vmr.Check(c)
 	if err != nil {
 		return err
 	}
@@ -335,7 +328,7 @@ func (c *Client) CreateTemplate(vmr *VmRef) error {
 }
 
 func (c *Client) MonitorCmd(vmr *VmRef, command string) (monitorRes map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +343,7 @@ func (c *Client) MonitorCmd(vmr *VmRef, command string) (monitorRes map[string]i
 }
 
 func (c *Client) Sendkey(vmr *VmRef, qmKey string) error {
-	err := c.CheckVmRef(vmr)
+	err := vmr.Check(c)
 	if err != nil {
 		return err
 	}
@@ -410,7 +403,7 @@ func (c *Client) GetTaskExitstatus(taskUpid string) (exitStatus interface{}, err
 }
 
 func (c *Client) StatusChangeVm(vmr *VmRef, params map[string]interface{}, setStatus string) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return
 	}
@@ -462,7 +455,7 @@ func (c *Client) DeleteVm(vmr *VmRef) (exitStatus string, err error) {
 }
 
 func (c *Client) DeleteVmParams(vmr *VmRef, params map[string]interface{}) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return "", err
 	}
@@ -869,7 +862,7 @@ func (c *Client) DeleteVMDisks(
 
 // VzDump - Create backup
 func (c *Client) VzDump(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +884,7 @@ func (c *Client) VzDump(vmr *VmRef, params map[string]interface{}) (exitStatus i
 
 // DeleteVolume - Delete volume
 func (c *Client) DeleteVolume(vmr *VmRef, storageName string, volumeName string) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -912,7 +905,7 @@ func (c *Client) DeleteVolume(vmr *VmRef, storageName string, volumeName string)
 
 // CreateVNCProxy - Creates a TCP VNC proxy connections
 func (c *Client) CreateVNCProxy(vmr *VmRef, params map[string]interface{}) (vncProxyRes map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -935,7 +928,7 @@ func (c *Client) CreateVNCProxy(vmr *VmRef, params map[string]interface{}) (vncP
 
 // QemuAgentPing - Execute ping.
 func (c *Client) QemuAgentPing(vmr *VmRef) (pingRes map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -956,7 +949,7 @@ func (c *Client) QemuAgentPing(vmr *VmRef) (pingRes map[string]interface{}, err 
 
 // QemuAgentFileWrite - Writes the given file via guest agent.
 func (c *Client) QemuAgentFileWrite(vmr *VmRef, params map[string]interface{}) (err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return err
 	}
@@ -968,7 +961,7 @@ func (c *Client) QemuAgentFileWrite(vmr *VmRef, params map[string]interface{}) (
 
 // QemuAgentSetUserPassword - Sets the password for the given user to the given password.
 func (c *Client) QemuAgentSetUserPassword(vmr *VmRef, params map[string]interface{}) (result map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -990,7 +983,7 @@ func (c *Client) QemuAgentSetUserPassword(vmr *VmRef, params map[string]interfac
 
 // QemuAgentExec - Executes the given command in the vm via the guest-agent and returns an object with the pid.
 func (c *Client) QemuAgentExec(vmr *VmRef, params map[string]interface{}) (result map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1012,7 +1005,7 @@ func (c *Client) QemuAgentExec(vmr *VmRef, params map[string]interface{}) (resul
 
 // GetExecStatus - Gets the status of the given pid started by the guest-agent
 func (c *Client) GetExecStatus(vmr *VmRef, pid string) (status map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1025,7 +1018,7 @@ func (c *Client) GetExecStatus(vmr *VmRef, pid string) (status map[string]interf
 
 // SetQemuFirewallOptions - Set Firewall options.
 func (c *Client) SetQemuFirewallOptions(vmr *VmRef, fwOptions map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1047,7 +1040,7 @@ func (c *Client) SetQemuFirewallOptions(vmr *VmRef, fwOptions map[string]interfa
 
 // GetQemuFirewallOptions - Get VM firewall options.
 func (c *Client) GetQemuFirewallOptions(vmr *VmRef) (firewallOptions map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1065,7 +1058,7 @@ func (c *Client) GetQemuFirewallOptions(vmr *VmRef) (firewallOptions map[string]
 
 // CreateQemuIPSet - Create new IPSet
 func (c *Client) CreateQemuIPSet(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1087,7 +1080,7 @@ func (c *Client) CreateQemuIPSet(vmr *VmRef, params map[string]interface{}) (exi
 
 // AddQemuIPSet - Add IP or Network to IPSet.
 func (c *Client) AddQemuIPSet(vmr *VmRef, name string, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1109,7 +1102,7 @@ func (c *Client) AddQemuIPSet(vmr *VmRef, name string, params map[string]interfa
 
 // GetQemuIPSet - List IPSets
 func (c *Client) GetQemuIPSet(vmr *VmRef) (ipsets map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1127,7 +1120,7 @@ func (c *Client) GetQemuIPSet(vmr *VmRef) (ipsets map[string]interface{}, err er
 
 // DeleteQemuIPSet - Delete IPSet
 func (c *Client) DeleteQemuIPSet(vmr *VmRef, IPSetName string) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -1148,7 +1141,7 @@ func (c *Client) DeleteQemuIPSet(vmr *VmRef, IPSetName string) (exitStatus inter
 
 // DeleteQemuIPSetNetwork - Remove IP or Network from IPSet.
 func (c *Client) DeleteQemuIPSetNetwork(vmr *VmRef, IPSetName string, network string, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}

--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -142,7 +142,7 @@ func pendingGuestConfigFromApi(vmr *VmRef, client *Client) ([]interface{}, error
 	if err != nil {
 		return nil, err
 	}
-	if err = client.CheckVmRef(vmr); err != nil {
+	if err = vmr.Check(client); err != nil {
 		return nil, err
 	}
 	return client.getItemConfigInterfaceArray("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/pending", "Guest", "PENDING CONFIG")

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ListSnapshots(c *Client, vmr *VmRef) (rawSnapshots, error) {
-	err := c.CheckVmRef(vmr)
+	err := vmr.Check(c)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (config ConfigSnapshot) mapToApi() map[string]interface{} {
 }
 
 func (config ConfigSnapshot) Create(c *Client, vmr *VmRef) (err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return
 	}
@@ -123,7 +123,7 @@ const (
 )
 
 func (snapshot SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return
 	}
@@ -135,7 +135,7 @@ func (snapshot SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, e
 }
 
 func (snapshot SnapshotName) Rollback(c *Client, vmr *VmRef) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return
 	}
@@ -144,7 +144,7 @@ func (snapshot SnapshotName) Rollback(c *Client, vmr *VmRef) (exitStatus string,
 
 // Can only be used to update the description of an already existing snapshot
 func (snapshot SnapshotName) Update(c *Client, vmr *VmRef, description string) (err error) {
-	err = c.CheckVmRef(vmr)
+	err = vmr.Check(c)
 	if err != nil {
 		return
 	}

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -1,0 +1,62 @@
+package proxmox
+
+import "errors"
+
+func NewVmRef(vmId int) (vmr *VmRef) {
+	vmr = &VmRef{vmId: vmId, node: "", vmType: ""}
+	return
+}
+
+// VmRef - virtual machine ref parts
+// map[type:qemu node:proxmox1-xx id:qemu/132 diskread:5.57424738e+08 disk:0 netin:5.9297450593e+10 mem:3.3235968e+09 uptime:1.4567097e+07 vmid:132 template:0 maxcpu:2 netout:6.053310416e+09 maxdisk:3.4359738368e+10 maxmem:8.592031744e+09 diskwrite:1.49663619584e+12 status:running cpu:0.00386980694947209 name:appt-app1-dev.xxx.xx]
+type VmRef struct {
+	vmId    int
+	node    string
+	pool    string
+	vmType  string
+	haState string
+	haGroup string
+}
+
+func (vmr *VmRef) GetVmType() string {
+	return vmr.vmType
+}
+
+func (vmr *VmRef) HaGroup() string {
+	return vmr.haGroup
+}
+
+func (vmr *VmRef) HaState() string {
+	return vmr.haState
+}
+
+func (vmr *VmRef) nilCheck() error {
+	if vmr == nil {
+		return errors.New("vm reference may not be nil")
+	}
+	return nil
+}
+
+func (vmr *VmRef) Node() string {
+	return vmr.node
+}
+
+func (vmr *VmRef) Pool() string {
+	return vmr.pool
+}
+
+func (vmr *VmRef) SetNode(node string) {
+	vmr.node = node
+}
+
+func (vmr *VmRef) SetPool(pool string) {
+	vmr.pool = pool
+}
+
+func (vmr *VmRef) SetVmType(vmType string) {
+	vmr.vmType = vmType
+}
+
+func (vmr *VmRef) VmId() int {
+	return vmr.vmId
+}

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -18,6 +18,10 @@ type VmRef struct {
 	haGroup string
 }
 
+const (
+	VmRef_Error_Nil string = "vm reference may not be nil"
+)
+
 func (vmr *VmRef) Check(c *Client) (err error) {
 	if vmr.node == "" || vmr.vmType == "" {
 		_, err = c.GetVmInfo(vmr)
@@ -39,7 +43,7 @@ func (vmr *VmRef) HaState() string {
 
 func (vmr *VmRef) nilCheck() error {
 	if vmr == nil {
-		return errors.New("vm reference may not be nil")
+		return errors.New(VmRef_Error_Nil)
 	}
 	return nil
 }

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -23,6 +23,10 @@ const (
 )
 
 func (vmr *VmRef) Check(c *Client) (err error) {
+	err = vmr.nilCheck()
+	if err != nil {
+		return
+	}
 	if vmr.node == "" || vmr.vmType == "" {
 		_, err = c.GetVmInfo(vmr)
 	}

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -18,6 +18,13 @@ type VmRef struct {
 	haGroup string
 }
 
+func (vmr *VmRef) Check(c *Client) (err error) {
+	if vmr.node == "" || vmr.vmType == "" {
+		_, err = c.GetVmInfo(vmr)
+	}
+	return
+}
+
 func (vmr *VmRef) GetVmType() string {
 	return vmr.vmType
 }

--- a/proxmox/vmref_test.go
+++ b/proxmox/vmref_test.go
@@ -1,0 +1,30 @@
+package proxmox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VmRef_nilCheck(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  *VmRef
+		output error
+	}{
+		{name: "Populated pointer",
+			input:  &VmRef{},
+			output: nil,
+		},
+		{name: "Empty pointer",
+			input:  nil,
+			output: errors.New(VmRef_Error_Nil),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.nilCheck())
+		})
+	}
+}


### PR DESCRIPTION
Work done:

- Moved the `VmRef` class/struct into it's own file (this should not have been in `client.go`) 0df16e7267abf6e46acb0ebf461d4d65f3ada950.
- Changed `Client.CheckVmRef()` to `VmRef.Check()` as it uses the `client` class but shouldn't be part of it 12e4f82bb04b0f89e6e029fab1f3a99e1ee228dd.
- Error for empty pointer to `*VmRef` is now a constant 53e674719a8079dce642b745a6e907c3707145d2.
- Add `nilCheck()` to `VmRef.Check()` preventing possible panic d5c6bed9034e3d1483ba7400f810401b91328730.
- Added unit test for `VmRef.nilCheck()` 8721be65f1787bcfc9a98ad739534d6ba2beb0af.