### PR TITLE
Fix: memory type conversion panic

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -467,6 +467,8 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 	// description:Base image
 	// cores:2 ostype:l26
 
+	var err error
+
 	config := ConfigQemu{}
 
 	if vmr != nil {
@@ -522,8 +524,10 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 	if _, isSet := params["hookscript"]; isSet {
 		config.Hookscript = params["hookscript"].(string)
 	}
-	if _, isSet := params["memory"]; isSet {
-		config.Memory = int(params["memory"].(float64))
+	if p, isSet := params["memory"]; isSet {
+		if config.Memory, err = toInt(p); err != nil {
+			return nil, err
+		}
 	}
 	if _, isSet := params["name"]; isSet {
 		config.Name = params["name"].(string)

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"errors"
 	"log"
 	"regexp"
 	"strconv"
@@ -8,6 +9,8 @@ import (
 )
 
 var rxUserTokenExtract = regexp.MustCompile("[a-z0-9]+@[a-z0-9]+!([a-z0-9]+)")
+
+const TypeConversion_Error_int = "could not convert to int"
 
 func inArray(arr []string, str string) bool {
 	for _, elem := range arr {
@@ -237,4 +240,15 @@ func splitStringOfSettings(settings string) map[string]interface{} {
 		settingMap[keyValuePair[0]] = value
 	}
 	return settingMap
+}
+
+func toInt(param interface{}) (int, error) {
+	switch p := param.(type) {
+	case float64:
+		return int(p), nil
+	case string:
+		mem, err := strconv.ParseFloat(p, 64)
+		return int(mem), err
+	}
+	return 0, errors.New(TypeConversion_Error_int)
 }


### PR DESCRIPTION
Related to https://github.com/Telmate/proxmox-api-go/issues/283

In Proxmox 8.0.4 the memory property is a number encoded as a string.
Added a function for obtaining the int value from the API, in the future we should use this function instead of direct type casting.